### PR TITLE
fix: handle connection gone exception

### DIFF
--- a/api/websocket/main.py
+++ b/api/websocket/main.py
@@ -88,9 +88,12 @@ def _get_event_body(event):
 
 def _send_to_connection(connection_id, data):
     endpoint = os.environ['WEBSOCKET_API_ENDPOINT']
-    # TODO: try and skip if gone by time of attempt
     print(f"Posting message: {str(data)}")
     gatewayapi = boto3.client("apigatewaymanagementapi",
-                              endpoint_url=endpoint)
-    return gatewayapi.post_to_connection(ConnectionId=connection_id,
-                                         Data=data.encode('utf-8'))
+                                endpoint_url=endpoint)
+    try:
+        return gatewayapi.post_to_connection(ConnectionId=connection_id,
+                                            Data=data.encode('utf-8'))
+    except gatewayapi.meta.client.exceptions.GoneException as e:
+        print(f"Connection {connection_id} Not Found: {e}")
+        delete_connection(connection_id)


### PR DESCRIPTION
Sometimes a connection is gone by the time we try to push to it which throws and exception and causes all subsequent messages to not be sent. This handles it by disconnecting it and continuing.